### PR TITLE
debian.control: fix lib*-dev naming pattern for produced package

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -9,10 +9,12 @@ Standards-Version: 1.0.0
 Section: devel
 Priority: extra
 
-Package: fty-utils-dev
+Package: libfty-utils-dev
 Architecture: any
+Provides: fty-utils-dev
 Depends:
   libfmt-dev
   ${shlibs:Depends},
   ${misc:Depends}
 Description: Single header library with severals tools
+ Note the historic misnomer "fty-utils-dev" is an alias for this package


### PR DESCRIPTION
Updates the package name to proper one, declares an alias (that it Provides) the old name.
Similar change verified in-place on OBS as a hotfix.